### PR TITLE
fix: replace unmaintained coveralls Gradle plugin with coverallsapp/github-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,14 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          CI_NAME: github-actions
-          CI_JOB_ID: ${{ github.run_id }}
-          CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: ./gradlew build coveralls
+        run: ./gradlew build
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/reports/jacoco/coverage/coverage.xml
+          format: jacoco
       - name: Upload Reports
         if: failure()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -40,7 +40,6 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.2")   // https://plugins.gradle.org/plugin/com.github.kt3k.coveralls
     implementation("org.javamodularity:moduleplugin:1.8.15")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("io.github.gradle-nexus:publish-plugin:2.0.0")                           // https://plugins.gradle.org/plugin/io.github.gradle-nexus.publish-plugin
     implementation("org.creekservice:creek-system-test-gradle-plugin:0.4.1")                // https://plugins.gradle.org/plugin/org.creekservice.system.test


### PR DESCRIPTION
The coveralls-gradle-plugin v2.12.2 has not been maintained since 2021 and uses the `getDependencyProject()` API that was removed in Gradle 9, causing builds to fail with Gradle 9.x.

Replace with the `coverallsapp/github-action` GitHub Action which uploads the Jacoco XML report directly to Coveralls without a Gradle plugin.