### PR TITLE
fix: upgrade release job Gradle action to fix build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
         with:
           gradle-home-cache-cleanup: true
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
## Root Cause

The `release` job in `.github/workflows/build.yml` was using the deprecated `gradle/gradle-build-action@v3.5.0` action. Its **Post Setup Gradle** cleanup step runs an `init.gradle` script that tries to *read* the `removeUnusedEntriesOlderThan` property from Gradle's cache configuration. This property became **write-only** in Gradle 9.x, causing the following error:

```
Cannot get the value of write-only property 'removeUnusedEntriesOlderThan' for object of type
org.gradle.api.internal.cache.DefaultCacheConfigurations$DefaultCacheResourceConfiguration.
```

## Fix

Upgrade the `release` job's Setup Gradle step from the deprecated `gradle/gradle-build-action@v3.5.0` to `gradle/actions/setup-gradle@v6.0.1` — the same version already used successfully by the `build_linux` job.

## Change

```diff
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
```