### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.